### PR TITLE
Added ability to change nodemanager service name and small fix

### DIFF
--- a/fmw_domain/attributes/default.rb
+++ b/fmw_domain/attributes/default.rb
@@ -3,7 +3,7 @@ include_attribute 'fmw_wls'
 default['fmw_domain']['nodemanager_port']               = 5556
 default['fmw_domain']['nodemanager_service_description'] = nil
 
-if node['platform_family']?('windows')
+if node['platform_family'] =='windows'
   default['fmw_domain']['domains_dir']    = 'C:/oracle/middleware/user_projects/domains'
   default['fmw_domain']['apps_dir']       = 'C:/oracle/middleware/user_projects/applications'
 

--- a/fmw_domain/attributes/default.rb
+++ b/fmw_domain/attributes/default.rb
@@ -3,7 +3,7 @@ include_attribute 'fmw_wls'
 default['fmw_domain']['nodemanager_port']               = 5556
 default['fmw_domain']['nodemanager_service_description'] = nil
 
-if platform_family?('windows')
+if node['platform_family']?('windows')
   default['fmw_domain']['domains_dir']    = 'C:/oracle/middleware/user_projects/domains'
   default['fmw_domain']['apps_dir']       = 'C:/oracle/middleware/user_projects/applications'
 
@@ -17,7 +17,7 @@ else
   default['fmw_domain']['apps_dir']       = '/opt/oracle/middleware/user_projects/applications'
 end
 
-case platform_family
+case node['platform_family']
 when 'debian', 'rhel'
   default['fmw']['orainst_dir']       = '/etc'
   default['fmw']['user_home_dir']     = '/home'

--- a/fmw_domain/attributes/default.rb
+++ b/fmw_domain/attributes/default.rb
@@ -1,6 +1,7 @@
 include_attribute 'fmw_wls'
 
 default['fmw_domain']['nodemanager_port']               = 5556
+default['fmw_domain']['nodemanager_service_description'] = nil
 
 if platform_family?('windows')
   default['fmw_domain']['domains_dir']    = 'C:/oracle/middleware/user_projects/domains'

--- a/fmw_domain/providers/nodemanager_service_windows.rb
+++ b/fmw_domain/providers/nodemanager_service_windows.rb
@@ -47,7 +47,7 @@ action :configure do
       service_check_name = '#{local_prod_name} NodeManager'
     else
       if new_resource.prod_name.nil? or new_resource.prod_name == ''
-        local_prod_name = 'Oracle Weblogic'
+        local_prod_name = 'Oracle Weblogic #{new_resource.domain_name}'
       else
         local_prod_name = new_resource.prod_name
       end
@@ -70,6 +70,7 @@ action :configure do
     end
 
     if exists == false
+      Chef::Log.info("PROD_NAME: " + local_prod_name)
       if new_resource.version == '10.3.6'
         execute 'add NodeManager service 11g' do
           command 'installNodeMgrSvc.cmd'
@@ -80,6 +81,11 @@ action :configure do
                          'SERVICE_DESCRIPTION' => new_resource.service_description })
         end
       else
+        cmd_file_name = ::File.join(new_resource.bin_dir, 'installNodeMgrSvc.cmd')
+        file_content = ::File.read(cmd_file_name)
+        file_content = file_content.gsub(/^set PROD_NAME=.*$/, "")
+        ::File.open(cmd_file_name, "w") {|file| file.puts file_content }
+
         execute 'add NodeManager service 12c' do
           command 'installNodeMgrSvc.cmd'
           cwd new_resource.bin_dir

--- a/fmw_domain/providers/nodemanager_service_windows.rb
+++ b/fmw_domain/providers/nodemanager_service_windows.rb
@@ -24,6 +24,7 @@ def load_current_resource
   @current_resource.bin_dir(@new_resource.bin_dir)
   @current_resource.java_home_dir(@new_resource.java_home_dir)
   @current_resource.prod_name(@new_resource.prod_name)
+  @current_resource.service_description(@new_resource.service_description)
   @current_resource
 end
 
@@ -46,11 +47,11 @@ action :configure do
       service_check_name = '#{local_prod_name} NodeManager'
     else
       if new_resource.prod_name.nil? or new_resource.prod_name == ''
-        local_prod_name = 'OracleWeblogic'
+        local_prod_name = 'Oracle Weblogic'
       else
         local_prod_name = new_resource.prod_name
       end
-      service_check_name = "#{local_prod_name} #{new_resource.domain_name} NodeManager"
+      service_check_name = "#{local_prod_name} NodeManager"
     end
 
     # check the existence and the service name
@@ -75,7 +76,8 @@ action :configure do
           cwd new_resource.bin_dir
           environment ({ 'CLASSPATH' => "#{new_resource.middleware_home_dir}\\wlserver_10.3\\server\\lib\\weblogic.jar",
                          'JAVA_HOME' => new_resource.java_home_dir,
-                         'PROD_NAME'    => local_prod_name })
+                         'PROD_NAME'    => local_prod_name,
+                         'SERVICE_DESCRIPTION' => new_resource.service_description })
         end
       else
         execute 'add NodeManager service 12c' do
@@ -84,7 +86,8 @@ action :configure do
           environment ({ 'JAVA_OPTIONS' => "-Dohs.product.home=#{new_resource.middleware_home_dir} -Dweblogic.RootDirectory=#{new_resource.domain_dir}",
                          'JAVA_HOME'    => new_resource.java_home_dir,
                          'MW_HOME'      => new_resource.middleware_home_dir,
-                         'PROD_NAME'    => local_prod_name })
+                         'PROD_NAME'    => local_prod_name,
+                         'SERVICE_DESCRIPTION' => new_resource.service_description })
         end
       end
       # do it in a block so it executed after the adding the nodemanager service

--- a/fmw_domain/providers/nodemanager_service_windows.rb
+++ b/fmw_domain/providers/nodemanager_service_windows.rb
@@ -23,6 +23,7 @@ def load_current_resource
   @current_resource.version(@new_resource.version)
   @current_resource.bin_dir(@new_resource.bin_dir)
   @current_resource.java_home_dir(@new_resource.java_home_dir)
+  @current_resource.prod_name(@new_resource.prod_name)
   @current_resource
 end
 
@@ -37,9 +38,19 @@ action :configure do
     service_name = nil
 
     if new_resource.version == '10.3.6'
-      service_check_name = 'Oracle WebLogic NodeManager'
+      if new_resource.prod_name.nil? or new_resource.prod_name == ''
+        local_prod_name = 'Oracle Weblogic'
+      else
+        local_prod_name = new_resource.prod_name
+      end
+      service_check_name = '#{local_prod_name} NodeManager'
     else
-      service_check_name = "Oracle Weblogic #{new_resource.domain_name} NodeManager"
+      if new_resource.prod_name.nil? or new_resource.prod_name == ''
+        local_prod_name = 'OracleWeblogic'
+      else
+        local_prod_name = new_resource.prod_name
+      end
+      service_check_name = "#{local_prod_name} #{new_resource.domain_name} NodeManager"
     end
 
     # check the existence and the service name
@@ -63,7 +74,8 @@ action :configure do
           command 'installNodeMgrSvc.cmd'
           cwd new_resource.bin_dir
           environment ({ 'CLASSPATH' => "#{new_resource.middleware_home_dir}\\wlserver_10.3\\server\\lib\\weblogic.jar",
-                         'JAVA_HOME' => new_resource.java_home_dir })
+                         'JAVA_HOME' => new_resource.java_home_dir,
+                         'PROD_NAME'    => local_prod_name })
         end
       else
         execute 'add NodeManager service 12c' do
@@ -71,7 +83,8 @@ action :configure do
           cwd new_resource.bin_dir
           environment ({ 'JAVA_OPTIONS' => "-Dohs.product.home=#{new_resource.middleware_home_dir} -Dweblogic.RootDirectory=#{new_resource.domain_dir}",
                          'JAVA_HOME'    => new_resource.java_home_dir,
-                         'MW_HOME'      => new_resource.middleware_home_dir })
+                         'MW_HOME'      => new_resource.middleware_home_dir,
+                         'PROD_NAME'    => local_prod_name })
         end
       end
       # do it in a block so it executed after the adding the nodemanager service

--- a/fmw_domain/recipes/nodemanager.rb
+++ b/fmw_domain/recipes/nodemanager.rb
@@ -26,13 +26,21 @@ if ['10.3.6'].include?(node['fmw']['version'])
   bin_dir               = "#{node['fmw']['weblogic_home_dir']}/server/bin"
   nodemanager_template  = 'nodemanager.properties_11g'
   nodemanager_check     = node['fmw']['weblogic_home_dir']
-  script_name           = "nodemanager_11g"
+  if node['fmw']['prod_name'].nil? or node['fmw']['prod_name'] == ''
+    script_name           = "nodemanager_11g"
+  else
+    script_name           = "#{node['fmw']['prod_name']}_nodemanager_11g"
+  end
 else
   nodemanager_home_dir  = "#{node['fmw_domain']['domains_dir']}/#{domain_params['domain_name']}/nodemanager"
   bin_dir               = "#{node['fmw_domain']['domains_dir']}/#{domain_params['domain_name']}/bin"
   nodemanager_template  = 'nodemanager.properties_12c'
   nodemanager_check     = "#{node['fmw_domain']['domains_dir']}/#{domain_params['domain_name']}"
-  script_name           = "nodemanager_#{domain_params['domain_name']}"
+  if node['fmw']['prod_name'].nil? or node['fmw']['prod_name'] == ''
+    script_name           = "nodemanager_11g"
+  else
+    script_name           = "#{node['fmw']['prod_name']}_nodemanager_#{domain_params['domain_name']}"
+  end
 end
 
 nodemanager_log_file  = "#{nodemanager_home_dir}/nodemanager.log"
@@ -141,6 +149,7 @@ elsif node['os'].include?('windows')
         res.middleware_home_dir node['fmw']['middleware_home_dir']
         res.bin_dir             bin_dir
         res.java_home_dir       node['fmw']['java_home_dir']
+        res.prod_name           node['fmw']['prod_name']
         res.run_action          :configure
       end
     end
@@ -152,6 +161,7 @@ elsif node['os'].include?('windows')
       middleware_home_dir node['fmw']['middleware_home_dir']
       bin_dir             bin_dir
       java_home_dir       node['fmw']['java_home_dir']
+      prod_name           node['fmw']['prod_name']
     end
   end
 

--- a/fmw_domain/recipes/nodemanager.rb
+++ b/fmw_domain/recipes/nodemanager.rb
@@ -150,6 +150,7 @@ elsif node['os'].include?('windows')
         res.bin_dir             bin_dir
         res.java_home_dir       node['fmw']['java_home_dir']
         res.prod_name           node['fmw']['prod_name']
+        res.service_description node['fmw_domain']['nodemanager_service_description']
         res.run_action          :configure
       end
     end
@@ -162,6 +163,7 @@ elsif node['os'].include?('windows')
       bin_dir             bin_dir
       java_home_dir       node['fmw']['java_home_dir']
       prod_name           node['fmw']['prod_name']
+      service_description node['fmw_domain']['nodemanager_service_description']
     end
   end
 

--- a/fmw_domain/resources/nodemanager_service_windows.rb
+++ b/fmw_domain/resources/nodemanager_service_windows.rb
@@ -24,3 +24,5 @@ attribute :version, kind_of: String, required: true
 attribute :bin_dir, kind_of: String, required: true
 # java home path
 attribute :java_home_dir, kind_of: String, required: true
+# prod name for product re-branding
+attribute :prod_name, kind_of: String, required: false, default: nil

--- a/fmw_domain/resources/nodemanager_service_windows.rb
+++ b/fmw_domain/resources/nodemanager_service_windows.rb
@@ -26,3 +26,5 @@ attribute :bin_dir, kind_of: String, required: true
 attribute :java_home_dir, kind_of: String, required: true
 # prod name for product re-branding
 attribute :prod_name, kind_of: String, required: false, default: nil
+# service description for product re-branding
+attribute :service_description, kind_of: String, required: false, default: nil

--- a/fmw_wls/attributes/default.rb
+++ b/fmw_wls/attributes/default.rb
@@ -1,6 +1,7 @@
 
 default['fmw']['version']                 = '12.1.3' # 10.3.6|12.1.1|12.1.2|12.1.3|12.2.1|12.2.1.1|12.2.1.2
 default['fmw_wls']['install_type']        = 'wls' # infra or wls
+default['fmw']['prod_name']               = nil
 
 if platform_family?('windows')
   default['fmw']['middleware_home_dir']   = 'C:/oracle/middleware'


### PR DESCRIPTION
Hello,

we need the possiblity to rename the nodemanager service, this is why I extended the nodemanager_service resource to be able to specify a PROD_NAME.
We are running our product on Windows Server currently, but this might chanage. Anyhow, I did not test the changes on Linux machines - but as I understood the resource, the name of the deamon script will change accordingly.

We need this possibility because we are using weblogic and OSB under OEM licencing model in our product.

Additionally I fixed a warning regarding attributes in fmw_domain cookbook.

Regards
Stephan