### PR TITLE
Issue#26 switched extract from unzip to jar xvf

### DIFF
--- a/fmw_opatch/providers/fmw_extract_windows.rb
+++ b/fmw_opatch/providers/fmw_extract_windows.rb
@@ -19,6 +19,7 @@ def load_current_resource
   @current_resource.tmp_dir(@new_resource.tmp_dir)
   @current_resource.version(@new_resource.version)
   @current_resource.middleware_home_dir(@new_resource.middleware_home_dir)
+  @current_resource.java_home_dir(@new_resource.java_home_dir)
 
   @current_resource.exists = true if ::File.exist?("#{@new_resource.tmp_dir}/#{@new_resource.name}")
 
@@ -33,16 +34,8 @@ action :extract do
   else
     converge_by("Create resource #{ @new_resource }") do
 
-      if @new_resource.version == '10.3.6'
-        path = "#{@new_resource.middleware_home_dir}\\wlserver_10.3\\server\\adr"
-      elsif new_resource.version == '12.1.1'
-        path = "#{@new_resource.middleware_home_dir}\\wlserver_12.1\\server\\adr"
-      else
-        path = "#{@new_resource.middleware_home_dir}\\oracle_common\\adr"
-      end
-
       execute "extract #{new_resource.name} file" do
-        command "#{path}\\unzip.exe -o #{new_resource.source_file} -d #{new_resource.tmp_dir}"
+        command "#{new_resource.java_home_dir}\\bin\\jar.exe xvf #{new_resource.source_file}"
         cwd new_resource.tmp_dir
       end
 

--- a/fmw_opatch/recipes/weblogic.rb
+++ b/fmw_opatch/recipes/weblogic.rb
@@ -26,6 +26,7 @@ fmw_opatch_fmw_extract node['fmw_opatch']['weblogic_patch_id'] do
   os_group            node['fmw']['os_group']            if ['solaris2', 'linux'].include?(node['os'])
   tmp_dir             node['fmw']['tmp_dir']
   middleware_home_dir node['fmw']['middleware_home_dir'] if node['os'].include?('windows')
+  java_home_dir       node['fmw']['java_home_dir']       if node['os'].include?('windows')
   version             node['fmw']['version']             if node['os'].include?('windows')
 end
 

--- a/fmw_opatch/resources/fmw_extract_windows.rb
+++ b/fmw_opatch/resources/fmw_extract_windows.rb
@@ -16,6 +16,8 @@ default_action :extract
 attribute :version, kind_of: String, required: true
 # middleware home path
 attribute :middleware_home_dir, kind_of: String, required: true
+# Java home folder
+attribute :java_home_dir, kind_of: String, required: true
 # Opatch source file
 attribute :source_file, kind_of: String, required: true
 # tmp folder


### PR DESCRIPTION
Apologies, a new pull request on Issue#26 branch to separate the pull request from Issue#28.

https://github.com/oracle/fmw-chef-cookbook/issues/26

The jar xvf command is able to support long filenames in windows and therefore can be used to solve the issues present with unzip.exe. A further advantage of this change is it simplifies the scripts as the indirection between weblogic versions in deriving the path to unzip.exe as it is no longer required.

Signed-off-by: Stuart Stephen <stuart.stephen@gmail.com>