### PR TITLE
Issue#31 Node Managers are hard coded to use secure listeners.

### DIFF
--- a/fmw_domain/attributes/default.rb
+++ b/fmw_domain/attributes/default.rb
@@ -1,6 +1,7 @@
 include_attribute 'fmw_wls'
 
 default['fmw_domain']['nodemanager_port']               = 5556
+default['fmw_domain']['nodemanager_secure_listener']    = true
 default['fmw_domain']['nodemanager_service_description'] = nil
 
 if node['platform_family'] =='windows'

--- a/fmw_domain/recipes/nodemanager.rb
+++ b/fmw_domain/recipes/nodemanager.rb
@@ -56,7 +56,7 @@ if node['os'].include?('windows')
               domain_dir:                    "#{node['fmw_domain']['domains_dir']}/#{domain_params['domain_name']}".gsub('\\\\', '/').gsub('\\', '/'),
               nodemanager_address:           node['fmw_domain']['nodemanager_listen_address'],
               nodemanager_port:              node['fmw_domain']['nodemanager_port'],
-              nodemanager_secure_listener:   true,
+              nodemanager_secure_listener:   node['fmw_domain']['nodemanager_secure_listener'],
               platform_family:               node['platform_family'],
               version:                       node['fmw']['version'])
   end
@@ -73,7 +73,7 @@ else
               domain_dir:                    "#{node['fmw_domain']['domains_dir']}/#{domain_params['domain_name']}",
               nodemanager_address:           node['fmw_domain']['nodemanager_listen_address'],
               nodemanager_port:              node['fmw_domain']['nodemanager_port'],
-              nodemanager_secure_listener:   true,
+              nodemanager_secure_listener:   node['fmw_domain']['nodemanager_secure_listener'],
               platform_family:               node['platform_family'],
               version:                       node['fmw']['version'])
   end


### PR DESCRIPTION
https://github.com/oracle/fmw-chef-cookbook/issues/31

Allows chef scripts to implement both secure and non secure node manager listeners.